### PR TITLE
feat: 지출처(payee) 필드 추가 및 메모 선택 필드로 변경

### DIFF
--- a/app/(main)/add/page.tsx
+++ b/app/(main)/add/page.tsx
@@ -104,6 +104,7 @@ export default function AddPage() {
     const [transactionType, setTransactionType] = useState<TransactionType>('expense')
     const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
     const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+    const [payee, setPayee] = useState("")
     const [description, setDescription] = useState("")
     const [selectedDate, setSelectedDate] = useState(new Date())
     const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
@@ -161,7 +162,8 @@ export default function AddPage() {
     const handleChipTap = (template: FrequentTransaction) => {
         setTransactionType(template.transaction_type as TransactionType)
         setSelectedCategory(template.category_id)
-        setDescription(template.description)
+        setPayee(template.payee)
+        setDescription(template.description ?? "")
         if (template.amount != null) {
             setAmount(String(template.amount))
         }
@@ -208,7 +210,8 @@ export default function AddPage() {
                 amount: Number(amount),
                 category_id: selectedCategory,
                 member_id: selectedMemberId,
-                description: description,
+                payee: payee,
+                description: description.trim() || null,
                 date: formatDateForDB(selectedDate),
                 transaction_type: transactionType,
             })
@@ -218,7 +221,8 @@ export default function AddPage() {
                 const result = await addFrequentTransaction({
                     transaction_type: transactionType,
                     category_id: selectedCategory,
-                    description: description,
+                    payee: payee,
+                    description: description.trim() || null,
                     amount: amount ? Number(amount) : null,
                 })
                 if (!result.success && result.error) {
@@ -240,7 +244,7 @@ export default function AddPage() {
         setIsCategoryOpen(false)
     }
 
-    const isValid = amount.length > 0 && selectedCategory !== null && description.trim().length > 0 && !saving
+    const isValid = amount.length > 0 && selectedCategory !== null && payee.trim().length > 0 && !saving
 
     if (loading) {
         return (
@@ -265,6 +269,7 @@ export default function AddPage() {
                     type="button"
                     onClick={() => {
                         setAmount("")
+                        setPayee("")
                         setDescription("")
                         setSaveAsTemplate(false)
                     }}
@@ -361,14 +366,31 @@ export default function AddPage() {
                     <ChevronDown className="w-5 h-5 text-gray-500" />
                 </button>
 
-                {/* Description Input */}
-                <div className="bg-white rounded-2xl p-4 shadow-sm">
+                {/* Payee Input (지출처 - 필수) */}
+                <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+                    <div className="px-4 pt-3 pb-1">
+                        <span className="text-[10px] font-semibold text-[#0047AB] uppercase tracking-wider">지출처 <span className="text-red-500">*</span></span>
+                    </div>
+                    <input
+                        type="text"
+                        value={payee}
+                        onChange={(e) => setPayee(e.target.value)}
+                        placeholder="어디서 사용했나요? (예: 스타벅스)"
+                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm px-4 pb-3"
+                    />
+                </div>
+
+                {/* Description Input (메모 - 선택) */}
+                <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+                    <div className="px-4 pt-3 pb-1">
+                        <span className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">메모 <span className="text-gray-300">(선택)</span></span>
+                    </div>
                     <input
                         type="text"
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
-                        placeholder="설명을 입력하세요"
-                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm"
+                        placeholder="추가 메모를 입력하세요"
+                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm px-4 pb-3"
                     />
                 </div>
 
@@ -533,8 +555,11 @@ export default function AddPage() {
                                                 </span>
                                             </div>
                                             <span className="mt-1 text-sm font-semibold text-gray-900 truncate">
-                                                {template.description}
+                                                {template.payee}
                                             </span>
+                                            {template.description && (
+                                                <span className="text-xs text-gray-400 truncate">{template.description}</span>
+                                            )}
                                         </div>
                                         {template.amount != null && (
                                             <span className="text-sm font-semibold text-gray-900 flex-shrink-0">

--- a/app/(main)/frequent-templates/page.tsx
+++ b/app/(main)/frequent-templates/page.tsx
@@ -71,6 +71,7 @@ interface SheetState {
     editId: string | null
     transactionType: TransactionType
     categoryId: string | null
+    payee: string
     description: string
     amountStr: string
     isCategoryOpen: boolean
@@ -82,6 +83,7 @@ const defaultSheet = (): SheetState => ({
     editId: null,
     transactionType: 'expense',
     categoryId: null,
+    payee: '',
     description: '',
     amountStr: '',
     isCategoryOpen: false,
@@ -119,7 +121,8 @@ export default function FrequentTemplatesPage() {
             editId: t.id,
             transactionType: t.transaction_type as TransactionType,
             categoryId: t.category_id,
-            description: t.description,
+            payee: t.payee,
+            description: t.description ?? '',
             amountStr: t.amount != null ? String(t.amount) : '',
             isCategoryOpen: false,
         })
@@ -128,14 +131,15 @@ export default function FrequentTemplatesPage() {
     const closeSheet = () => setSheet(defaultSheet())
 
     const handleSave = async () => {
-        if (!sheet.categoryId || !sheet.description.trim()) return
+        if (!sheet.categoryId || !sheet.payee.trim()) return
         setSaving(true)
         try {
             if (sheet.mode === 'create') {
                 const result = await addFrequentTransaction({
                     transaction_type: sheet.transactionType,
                     category_id: sheet.categoryId,
-                    description: sheet.description.trim(),
+                    payee: sheet.payee.trim(),
+                    description: sheet.description.trim() || null,
                     amount: sheet.amountStr ? Number(sheet.amountStr) : null,
                 })
                 if (!result.success) {
@@ -146,7 +150,8 @@ export default function FrequentTemplatesPage() {
                 const result = await updateFrequentTransaction(sheet.editId, {
                     transaction_type: sheet.transactionType,
                     category_id: sheet.categoryId,
-                    description: sheet.description.trim(),
+                    payee: sheet.payee.trim(),
+                    description: sheet.description.trim() || null,
                     amount: sheet.amountStr ? Number(sheet.amountStr) : null,
                 })
                 if (!result.success) {
@@ -176,7 +181,7 @@ export default function FrequentTemplatesPage() {
     const getCategoryData = (categoryId: string) =>
         categories.find(c => c.id === categoryId)
 
-    const isSheetValid = sheet.categoryId && sheet.description.trim().length > 0
+    const isSheetValid = sheet.categoryId && sheet.payee.trim().length > 0
 
     if (loading) {
         return (
@@ -263,7 +268,10 @@ export default function FrequentTemplatesPage() {
                                         </span>
                                         <span className="text-xs text-gray-400">{cat?.name ?? '미분류'}</span>
                                     </div>
-                                    <p className="text-sm font-semibold text-gray-900 truncate">{template.description}</p>
+                                    <p className="text-sm font-semibold text-gray-900 truncate">{template.payee}</p>
+                                    {template.description && (
+                                        <p className="text-xs text-gray-400 truncate">{template.description}</p>
+                                    )}
                                     <div className="flex items-center gap-2 mt-0.5">
                                         {template.amount != null && (
                                             <span className="text-xs text-gray-500">
@@ -398,14 +406,26 @@ export default function FrequentTemplatesPage() {
                                     )}
                                 </div>
 
-                                {/* 메모 */}
+                                {/* 지출처 */}
                                 <div>
-                                    <label className="text-xs font-semibold text-gray-500 mb-2 block">메모 *</label>
+                                    <label className="text-xs font-semibold text-gray-500 mb-2 block">지출처 *</label>
+                                    <input
+                                        type="text"
+                                        value={sheet.payee}
+                                        onChange={(e) => setSheet(s => ({ ...s, payee: e.target.value }))}
+                                        placeholder="예: 스타벅스"
+                                        className="w-full bg-gray-50 rounded-2xl px-4 py-3.5 text-sm text-gray-900 placeholder:text-gray-400 outline-none border border-gray-100 focus:border-blue-300 transition-colors"
+                                    />
+                                </div>
+
+                                {/* 메모 (선택) */}
+                                <div>
+                                    <label className="text-xs font-semibold text-gray-500 mb-2 block">메모 <span className="text-gray-300">(선택)</span></label>
                                     <input
                                         type="text"
                                         value={sheet.description}
                                         onChange={(e) => setSheet(s => ({ ...s, description: e.target.value }))}
-                                        placeholder="예: 스타벅스 아메리카노"
+                                        placeholder="추가 메모를 입력하세요"
                                         className="w-full bg-gray-50 rounded-2xl px-4 py-3.5 text-sm text-gray-900 placeholder:text-gray-400 outline-none border border-gray-100 focus:border-blue-300 transition-colors"
                                     />
                                 </div>

--- a/app/(main)/history/[id]/page.tsx
+++ b/app/(main)/history/[id]/page.tsx
@@ -91,6 +91,7 @@ export default function TransactionDetailPage() {
     const [transactionType, setTransactionType] = useState<TransactionType>('expense')
     const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null)
     const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+    const [payee, setPayee] = useState("")
     const [description, setDescription] = useState("")
     const [selectedDate, setSelectedDate] = useState(new Date())
     const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
@@ -116,10 +117,11 @@ export default function TransactionDetailPage() {
                 setMembers(membersData)
 
                 if (transactionData) {
-                    // 기존 데이터로 폼 미리 일기
+                    // 기존 데이터로 폼 미리 읽기
                     setAmount(String(transactionData.amount))
                     setSelectedCategory(transactionData.category_id)
-                    setDescription(transactionData.description)
+                    setPayee(transactionData.payee ?? '')
+                    setDescription(transactionData.description ?? '')
                     setSelectedDate(new Date(transactionData.date))
                     setTransactionType((transactionData as any).transaction_type ?? 'expense')
 
@@ -198,7 +200,8 @@ export default function TransactionDetailPage() {
                 amount: Number(amount),
                 category_id: selectedCategory,
                 member_id: selectedMemberId,
-                description: description,
+                payee: payee,
+                description: description.trim() || null,
                 date: formatDateForDB(selectedDate),
                 transaction_type: transactionType,
             })
@@ -208,7 +211,8 @@ export default function TransactionDetailPage() {
                 const result = await addFrequentTransaction({
                     transaction_type: transactionType,
                     category_id: selectedCategory,
-                    description: description,
+                    payee: payee,
+                    description: description.trim() || null,
                     amount: amount ? Number(amount) : null,
                 })
                 if (!result.success && result.error) {
@@ -242,7 +246,7 @@ export default function TransactionDetailPage() {
         setIsCategoryOpen(false)
     }
 
-    const isValid = amount.length > 0 && selectedCategory !== null && description.trim().length > 0 && !saving
+    const isValid = amount.length > 0 && selectedCategory !== null && payee.trim().length > 0 && !saving
 
     if (loading) {
         return (
@@ -363,14 +367,31 @@ export default function TransactionDetailPage() {
                     <ChevronDown className="w-5 h-5 text-gray-500" />
                 </button>
 
-                {/* Description Input */}
-                <div className="bg-white rounded-2xl p-4 shadow-sm">
+                {/* Payee Input (지출처 - 필수) */}
+                <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+                    <div className="px-4 pt-3 pb-1">
+                        <span className="text-[10px] font-semibold text-[#0047AB] uppercase tracking-wider">지출처 <span className="text-red-500">*</span></span>
+                    </div>
+                    <input
+                        type="text"
+                        value={payee}
+                        onChange={(e) => setPayee(e.target.value)}
+                        placeholder="어디서 사용했나요? (예: 스타벅스)"
+                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm px-4 pb-3"
+                    />
+                </div>
+
+                {/* Description Input (메모 - 선택) */}
+                <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+                    <div className="px-4 pt-3 pb-1">
+                        <span className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider">메모 <span className="text-gray-300">(선택)</span></span>
+                    </div>
                     <input
                         type="text"
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
-                        placeholder="설명을 입력하세요"
-                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm"
+                        placeholder="추가 메모를 입력하세요"
+                        className="w-full bg-transparent text-gray-900 placeholder:text-gray-400 outline-none text-sm px-4 pb-3"
                     />
                 </div>
 

--- a/app/(main)/history/page.tsx
+++ b/app/(main)/history/page.tsx
@@ -485,12 +485,14 @@ export default function HistoryPage() {
                                                 {/* Description */}
                                                 <div className="flex-1 min-w-0">
                                                     <p className="font-medium text-gray-900 text-[15px] truncate flex items-center gap-1">
-                                                        <span>{item.category}</span>
+                                                        <span>{item.payee}</span>
                                                         <span className="text-xs text-gray-400">· {item.memberName}</span>
                                                     </p>
-                                                    <p className="text-xs text-gray-400 mt-0.5 truncate">
-                                                        {item.description}
-                                                    </p>
+                                                    {item.description && (
+                                                        <p className="text-xs text-gray-400 mt-0.5 truncate">
+                                                            {item.description}
+                                                        </p>
+                                                    )}
                                                 </div>
 
                                                 {/* Amount */}
@@ -696,10 +698,12 @@ export default function HistoryPage() {
 
                                             <div className="flex-1 min-w-0">
                                                 <p className="font-medium text-gray-900 text-[15px] truncate flex items-center gap-1">
-                                                    <span>{item.category}</span>
+                                                    <span>{item.payee}</span>
                                                     <span className="text-xs text-gray-400">· {item.memberName}</span>
                                                 </p>
-                                                <p className="text-sm text-gray-500 truncate">{item.description}</p>
+                                                {item.description && (
+                                                    <p className="text-sm text-gray-500 truncate">{item.description}</p>
+                                                )}
                                             </div>
 
                                             <p className="font-bold text-gray-900 text-base flex-shrink-0">

--- a/lib/supabase/mutations.ts
+++ b/lib/supabase/mutations.ts
@@ -7,7 +7,8 @@ export async function addTransaction(data: {
     amount: number
     category_id: string
     member_id: string
-    description: string
+    payee: string
+    description?: string | null
     date?: string
     transaction_type?: TransactionType
 }) {
@@ -24,7 +25,8 @@ export async function addTransaction(data: {
             amount: data.amount,
             category_id: data.category_id,
             member_id: data.member_id,
-            description: data.description,
+            payee: data.payee,
+            description: data.description ?? null,
             date: data.date || new Date().toISOString().split('T')[0],
             transaction_type: data.transaction_type || 'expense',
         }] as any)
@@ -44,7 +46,8 @@ export async function updateTransaction(id: string, data: Partial<{
     amount: number
     category_id: string
     member_id: string
-    description: string
+    payee: string
+    description: string | null
     date: string
     transaction_type: TransactionType
 }>) {
@@ -121,7 +124,8 @@ const FREQUENT_LIMIT = 15
 export async function addFrequentTransaction(data: {
     transaction_type: TransactionType
     category_id: string
-    description: string
+    payee: string
+    description?: string | null
     amount?: number | null
 }): Promise<{ success: boolean; error?: string; data?: FrequentTransaction }> {
     const groupId = await getCurrentGroupId()
@@ -134,7 +138,7 @@ export async function addFrequentTransaction(data: {
         .eq('group_id', groupId)
         .eq('transaction_type', data.transaction_type)
         .eq('category_id', data.category_id)
-        .eq('description', data.description)
+        .eq('payee', data.payee)
 
     if (data.amount != null) {
         duplicateQuery = duplicateQuery.eq('amount', data.amount)
@@ -165,7 +169,8 @@ export async function addFrequentTransaction(data: {
             group_id: groupId,
             transaction_type: data.transaction_type,
             category_id: data.category_id,
-            description: data.description,
+            payee: data.payee,
+            description: data.description ?? null,
             amount: data.amount ?? null,
         }] as any)
         .select()
@@ -185,7 +190,8 @@ export async function updateFrequentTransaction(
     data: Partial<{
         transaction_type: TransactionType
         category_id: string
-        description: string
+        payee: string
+        description: string | null
         amount: number | null
     }>
 ): Promise<{ success: boolean; error?: string }> {

--- a/migrations/002_add_payee_field.sql
+++ b/migrations/002_add_payee_field.sql
@@ -1,0 +1,44 @@
+-- =====================================================
+-- 마이그레이션 002: payee(지출처) 필드 추가
+-- 실행 일시: 2026-04-14
+-- 목적: 거래 내역에 지출처 필드를 별도로 관리
+--       기존 description 값 → payee로 마이그레이션
+--       description은 선택 필드(nullable)로 변경
+-- =====================================================
+
+-- 1. transactions 테이블에 payee 컬럼 추가 (기본값으로 기존 데이터 호환)
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS payee TEXT NOT NULL DEFAULT '';
+
+-- 2. 기존 description 값을 payee로 복사 (데이터 보존)
+UPDATE transactions
+  SET payee = description
+  WHERE payee = '';
+
+-- 3. transactions: description을 선택 필드(nullable)로 변경
+ALTER TABLE transactions
+  ALTER COLUMN description DROP NOT NULL;
+
+-- 4. transactions: payee의 DEFAULT 제거 (이후 신규 INSERT는 명시적 입력 필요)
+ALTER TABLE transactions
+  ALTER COLUMN payee DROP DEFAULT;
+
+-- 5. frequent_transactions에도 payee 컬럼 추가
+ALTER TABLE frequent_transactions
+  ADD COLUMN IF NOT EXISTS payee TEXT NOT NULL DEFAULT '';
+
+-- 6. frequent_transactions: 기존 description 값을 payee로 복사
+UPDATE frequent_transactions
+  SET payee = description
+  WHERE payee = '';
+
+-- 7. frequent_transactions: description을 선택 필드로 변경
+ALTER TABLE frequent_transactions
+  ALTER COLUMN description DROP NOT NULL;
+
+-- 8. frequent_transactions: payee의 DEFAULT 제거
+ALTER TABLE frequent_transactions
+  ALTER COLUMN payee DROP DEFAULT;
+
+-- 9. payee 인덱스 추가 (검색 성능 최적화)
+CREATE INDEX IF NOT EXISTS transactions_payee_idx ON transactions(payee);

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS transactions (
   amount INTEGER NOT NULL,
   category_id UUID NOT NULL REFERENCES categories(id) ON DELETE SET DEFAULT,
   member_id UUID NOT NULL REFERENCES members(id) ON DELETE CASCADE,
-  description TEXT NOT NULL,
+  payee TEXT NOT NULL,
+  description TEXT,
   date DATE NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
@@ -49,7 +50,8 @@ CREATE TABLE IF NOT EXISTS frequent_transactions (
   group_id UUID NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
   transaction_type TEXT NOT NULL,
   category_id UUID NOT NULL REFERENCES categories(id) ON DELETE SET DEFAULT,
-  description TEXT NOT NULL,
+  payee TEXT NOT NULL,
+  description TEXT,
   amount INTEGER NULL,
   usage_count INTEGER DEFAULT 0 NOT NULL,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
@@ -62,6 +64,7 @@ CREATE INDEX IF NOT EXISTS transactions_date_idx ON transactions(date);
 CREATE INDEX IF NOT EXISTS transactions_category_id_idx ON transactions(category_id);
 CREATE INDEX IF NOT EXISTS transactions_member_id_idx ON transactions(member_id);
 CREATE INDEX IF NOT EXISTS transactions_created_at_idx ON transactions(created_at);
+CREATE INDEX IF NOT EXISTS transactions_payee_idx ON transactions(payee);
 CREATE INDEX IF NOT EXISTS frequent_transactions_group_id_idx ON frequent_transactions(group_id);
 CREATE INDEX IF NOT EXISTS frequent_transactions_usage_count_idx ON frequent_transactions(usage_count DESC);
 
@@ -160,12 +163,12 @@ BEGIN
   SELECT id INTO shopping_id FROM categories WHERE name = '생활' LIMIT 1;
 
   -- 샘플 거래 추가 (MVP 그룹에만)
-  INSERT INTO transactions (group_id, amount, category_id, member_id, description, date) VALUES
-    (mvp_group_id, 45000, food_id, husband_id, '저녁 식사', CURRENT_DATE),
-    (mvp_group_id, 12000, transport_id, wife_id, '택시', CURRENT_DATE),
-    (mvp_group_id, 8500, cafe_id, husband_id, '스타벅스', CURRENT_DATE - 1),
-    (mvp_group_id, 125000, shopping_id, wife_id, '생활용품 구매', CURRENT_DATE - 1),
-    (mvp_group_id, 15000, food_id, husband_id, '편의점', CURRENT_DATE - 3);
+  INSERT INTO transactions (group_id, amount, category_id, member_id, payee, description, date) VALUES
+    (mvp_group_id, 45000, food_id, husband_id, '저녁 식사', NULL, CURRENT_DATE),
+    (mvp_group_id, 12000, transport_id, wife_id, '택시', NULL, CURRENT_DATE),
+    (mvp_group_id, 8500, cafe_id, husband_id, '스타벅스', NULL, CURRENT_DATE - 1),
+    (mvp_group_id, 125000, shopping_id, wife_id, '생활용품 구매', NULL, CURRENT_DATE - 1),
+    (mvp_group_id, 15000, food_id, husband_id, '편의점', NULL, CURRENT_DATE - 3);
 END $$;
 
 -- NOTE: current_group 뷰는 MVP 초기 임시 뷰로, 현재 앱에서 사용하지 않음 (삭제됨)

--- a/types/database.ts
+++ b/types/database.ts
@@ -24,7 +24,8 @@ export interface Database {
                     amount: number
                     category_id: string
                     member_id: string
-                    description: string
+                    payee: string
+                    description?: string | null
                     date: string
                 }
                 Update: Partial<{
@@ -32,7 +33,8 @@ export interface Database {
                     amount: number
                     category_id: string
                     member_id: string
-                    description: string
+                    payee: string
+                    description: string | null
                     date: string
                 }>
                 Relationships: [
@@ -118,7 +120,8 @@ export interface Transaction {
     amount: number
     category_id: string
     member_id: string
-    description: string
+    payee: string
+    description: string | null
     created_at: string
     date: string
     transaction_type: TransactionType
@@ -139,7 +142,8 @@ export interface FrequentTransaction {
     group_id: string
     transaction_type: TransactionType
     category_id: string
-    description: string
+    payee: string
+    description: string | null
     amount: number | null
     usage_count: number
     created_at: string
@@ -166,7 +170,8 @@ export interface TransactionUI {
     date: string
     rawDate: string // 원본 날짜 (YYYY-MM-DD)
     color: string
-    description: string
+    payee: string
+    description: string | null
     memberName: string // 지출자 이름
     transactionType: TransactionType
 }
@@ -200,7 +205,8 @@ export function transactionToUI(
         date: formatDate(transaction.date),
         rawDate: transaction.date,
         color: category.color,
-        description: transaction.description,
+        payee: transaction.payee,
+        description: transaction.description ?? null,
         memberName: member.name,
         transactionType: transaction.transaction_type ?? 'expense',
     }


### PR DESCRIPTION
## 💡 기능 요청 요약

기존 거래 내역에서는 `description`(메모) 필드 하나에 '지출처'와 '추가 메모'를 한 번에 기재하여, 목록이 지저분해지고 필터링/관리가 어려운 문제가 있었습니다. 
이를 해결하기 위해 지출처(`payee`)와 메모(`description`)를 명확히 분리하고, 입력 규칙을 개선했습니다.

## 🛠️ 변경 사항

### 1. DB (Supabase)
- `transactions`, `frequent_transactions` 테이블에 `payee TEXT NOT NULL` 컬럼 추가
- 기존에 필수였던 `description` 필드를 **선택 필드(nullable)** 로 변경
- `payee` 기반 검색 최적화를 위한 인덱스(`transactions_payee_idx`) 추가

### 2. 마이그레이션 (`migrations/002_add_payee_field.sql`)
- 기존에 작성된 `description` 값들을 데이터 손실 없이 **`payee` 필드로 자동 복사**
- 이후 `description` 필드는 NULL 처리되도록 설계

### 3. 기능 및 UI 개선
- **타입 및 Data Layer**: `Transaction`, `FrequentTransaction` 타입 및 생성/수정 Mutation(Supabase)에 `payee` 반영 완료
- **입력 폼 (Add / Edit / 템플릿 포함)**:
  - 🌟 **지출처(필수)** 입력 필드와 🌟 **메모(선택)** 필드로 UI 분리
- **내역 목록 (`History`)**:
  - 카드 UI의 메인 텍스트 영역에 카테고리 대신 **지출처가 노출**되도록 변경
  - 메모가 작성된 경우에만 보조 텍스트로 노출되도록 조건부 렌더링

## ✅ 검증 결과
- [x] yarn build 컴파일 통과 및 Type check 완료
- [x] 지출처 미입력 시 `isValid` false로 저장 버튼 비활성화 검증 완료
- [x] 마이그레이션 쿼리 정상 로직 확인

## 🚀 다음 후속 작업
- 로컬 DB 변경 후 클라우드 Supabase DB 환경에 SQL 마이그레이션 실행
